### PR TITLE
feat: adding in the pyproject.toml and setup.cfg for pip packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,18 @@ ehthumbs.db
 ################
 *~
 
+# Python packaging
+dist/
+build/
+*.egg-info/
+.eggs/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+.venv
+pip-selfcheck.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,3 @@
-# pyproject.toml
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "loop_wrapper"
+version = "3.2.0"
+description = "loop_wrapper is a job-control tool to make it easier to loop through datetime ranges"
+readme = "README.md"
+requires-python = ">=3.6"
+license = "GPL-2.0-only"
+keywords = ["loop", "datetime", "job-control"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+
+authors = [
+  { name="Thomas Lavergne", email="thomasl@met.no" },
+  { name="Mathew Duggan", email="mat@matduggan.com" },
+]
+
+dependencies = [
+  "python-dateutil>=2.9.0",
+]
+
+[project.urls]
+homepage = "https://github.com/metno/loop_wrapper"
+"Bug Tracker" = "https://github.com/metno/loop_wrapper/issues"
+documentation = "https://loop_wrapper.readthedocs.io/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
-# setup.cfg
 [metadata]
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+# setup.cfg
+[metadata]
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/metno/loop_wrapper
+
+[options]
+packages = find:
+python_requires = >=3.6
+
+[options.packages.find]
+where = .


### PR DESCRIPTION
This is the initial work for creating a pip package. I can confirm that the output of `python -m build` produces the correct artifacts. I will need a maintainer to create an account with testpypi and pypi and then let me know what the github environmental variable is so I can add a github action to bundle and push the package to Pip. Please see below for my local test to confirm that importing the package still passes the pytests. 

`Using temporary directory for environments: /var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh
Starting package installation and test verification script...

--- Testing installation from: loop_wrapper-3.2.0-py2.py3-none-any.whl ---
Creating virtual environment: venv_wheel_test
Activated virtual environment.
Installing test dependencies from ./requirements.txt
Requirement already satisfied: pip in /private/var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh/venv_wheel_test/lib/python3.13/site-packages (25.0.1)
Collecting pytest
  Downloading pytest-8.3.5-py3-none-any.whl.metadata (7.6 kB)
Collecting python-dateutil (from -r ./requirements.txt (line 1))
  Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting iniconfig (from pytest)
  Downloading iniconfig-2.1.0-py3-none-any.whl.metadata (2.7 kB)
Collecting packaging (from pytest)
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pluggy<2,>=1.5 (from pytest)
  Downloading pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting six>=1.5 (from python-dateutil->-r ./requirements.txt (line 1))
  Downloading six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Downloading pytest-8.3.5-py3-none-any.whl (343 kB)
Downloading python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Downloading pluggy-1.5.0-py3-none-any.whl (20 kB)
Downloading six-1.17.0-py2.py3-none-any.whl (11 kB)
Downloading iniconfig-2.1.0-py3-none-any.whl (6.0 kB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Installing collected packages: six, pluggy, packaging, iniconfig, python-dateutil, pytest
Successfully installed iniconfig-2.1.0 packaging-25.0 pluggy-1.5.0 pytest-8.3.5 python-dateutil-2.9.0.post0 six-1.17.0
Test dependencies installed.
Installing package: ./dist/loop_wrapper-3.2.0-py2.py3-none-any.whl
Processing ./dist/loop_wrapper-3.2.0-py2.py3-none-any.whl
Requirement already satisfied: python-dateutil>=2.9.0 in /private/var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh/venv_wheel_test/lib/python3.13/site-packages (from loop-wrapper==3.2.0) (2.9.0.post0)
Requirement already satisfied: six>=1.5 in /private/var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh/venv_wheel_test/lib/python3.13/site-packages (from python-dateutil>=2.9.0->loop-wrapper==3.2.0) (1.17.0)
Installing collected packages: loop-wrapper
Successfully installed loop-wrapper-3.2.0
Package installed successfully.
Running tests in ./test
======================================= test session starts =======================================
platform darwin -- Python 3.13.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/dkmatdug/Documents/work/loop_wrapper
configfile: pyproject.toml
collected 39 items

test/test_basic.py .....                                                                    [ 12%]
test/test_dateloop.py ..........                                                            [ 38%]
test/test_dateparse.py ..........                                                           [ 64%]
test/test_errorHandling.py ....                                                             [ 74%]
test/test_pll.py ....                                                                       [ 84%]
test/test_shellExpansion.py ......                                                          [100%]

======================================= 39 passed in 4.77s ========================================
Tests PASSED for loop_wrapper-3.2.0-py2.py3-none-any.whl.
Deactivated virtual environment: venv_wheel_test

--- Testing installation from: loop_wrapper-3.2.0.tar.gz ---
Creating virtual environment: venv_sdist_test
Activated virtual environment.
Installing test dependencies from ./requirements.txt
Requirement already satisfied: pip in /private/var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh/venv_sdist_test/lib/python3.13/site-packages (25.0.1)
Collecting pytest
  Using cached pytest-8.3.5-py3-none-any.whl.metadata (7.6 kB)
Collecting python-dateutil (from -r ./requirements.txt (line 1))
  Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl.metadata (8.4 kB)
Collecting iniconfig (from pytest)
  Using cached iniconfig-2.1.0-py3-none-any.whl.metadata (2.7 kB)
Collecting packaging (from pytest)
  Using cached packaging-25.0-py3-none-any.whl.metadata (3.3 kB)
Collecting pluggy<2,>=1.5 (from pytest)
  Using cached pluggy-1.5.0-py3-none-any.whl.metadata (4.8 kB)
Collecting six>=1.5 (from python-dateutil->-r ./requirements.txt (line 1))
  Using cached six-1.17.0-py2.py3-none-any.whl.metadata (1.7 kB)
Using cached pytest-8.3.5-py3-none-any.whl (343 kB)
Using cached python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Using cached pluggy-1.5.0-py3-none-any.whl (20 kB)
Using cached six-1.17.0-py2.py3-none-any.whl (11 kB)
Using cached iniconfig-2.1.0-py3-none-any.whl (6.0 kB)
Using cached packaging-25.0-py3-none-any.whl (66 kB)
Installing collected packages: six, pluggy, packaging, iniconfig, python-dateutil, pytest
Successfully installed iniconfig-2.1.0 packaging-25.0 pluggy-1.5.0 pytest-8.3.5 python-dateutil-2.9.0.post0 six-1.17.0
Test dependencies installed.
Installing package: ./dist/loop_wrapper-3.2.0.tar.gz
Processing ./dist/loop_wrapper-3.2.0.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: python-dateutil>=2.9.0 in /private/var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh/venv_sdist_test/lib/python3.13/site-packages (from loop_wrapper==3.2.0) (2.9.0.post0)
Requirement already satisfied: six>=1.5 in /private/var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh/venv_sdist_test/lib/python3.13/site-packages (from python-dateutil>=2.9.0->loop_wrapper==3.2.0) (1.17.0)
Building wheels for collected packages: loop_wrapper
  Building wheel for loop_wrapper (pyproject.toml) ... done
  Created wheel for loop_wrapper: filename=loop_wrapper-3.2.0-py3-none-any.whl size=16585 sha256=5590c2f063b8a8edb2bd1dab74526d0af3db1ed848a548ea6ac461ebb0f35ef8
  Stored in directory: /Users/dkmatdug/Library/Caches/pip/wheels/72/dc/45/d2cf1703f8827cfa06792f4206f84e12f53c8a9296189278da
Successfully built loop_wrapper
Installing collected packages: loop_wrapper
Successfully installed loop_wrapper-3.2.0
Package installed successfully.
Running tests in ./test
======================================= test session starts =======================================
platform darwin -- Python 3.13.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/dkmatdug/Documents/work/loop_wrapper
configfile: pyproject.toml
collected 39 items

test/test_basic.py .....                                                                    [ 12%]
test/test_dateloop.py ..........                                                            [ 38%]
test/test_dateparse.py ..........                                                           [ 64%]
test/test_errorHandling.py ....                                                             [ 74%]
test/test_pll.py ....                                                                       [ 84%]
test/test_shellExpansion.py ......                                                          [100%]

======================================= 39 passed in 3.65s ========================================
Tests PASSED for loop_wrapper-3.2.0.tar.gz.
Deactivated virtual environment: venv_sdist_test

--- Test Summary ---
Wheel installation and tests (loop_wrapper-3.2.0-py2.py3-none-any.whl): SUCCESS
SDist installation and tests (loop_wrapper-3.2.0.tar.gz): SUCCESS
--------------------
All installation tests PASSED!
Cleaning up temporary directory: /var/folders/d8/cy5c08p1493gds2lfkv2wv7h0000gp/T/loop_wrapper_test_venv_XXXX.BwWIUMl1bh`